### PR TITLE
Update partition metrics map in NR query supplier

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicQuerySupplier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicQuerySupplier.java
@@ -168,6 +168,6 @@ public final class NewRelicQuerySupplier {
         TOPIC_METRICS.put("messagesInPerSec", TOPIC_MESSAGES_IN_PER_SEC);
 
         // partition level metrics
-        PARTITION_METRICS.put("kafka_log_Log_Value_Size", PARTITION_SIZE);
+        PARTITION_METRICS.put("partitionSize", PARTITION_SIZE);
     }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/model/NewRelicQueryResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/model/NewRelicQueryResult.java
@@ -64,7 +64,7 @@ public class NewRelicQueryResult {
         // If facet is one item, this is a broker level query: facets = broker
         // If length of facets is 2, this is a topic level query: facets = [broker, topic]
         // If length of facets is 3, this is a partition level query: facets = [broker, topic, partition]
-        Map<String, RawMetricType> valueToMetricMap = NewRelicQuerySupplier.getBrokerMap();
+        Map<String, RawMetricType> valueToMetricMap;
         JsonNode facets = result.get(FACET_ATTR);
         if (facets.getNodeType() == JsonNodeType.ARRAY) {
             _brokerID = facets.get(0).asInt();
@@ -77,6 +77,7 @@ public class NewRelicQueryResult {
                 valueToMetricMap = NewRelicQuerySupplier.getTopicMap();
             }
         } else {
+            valueToMetricMap = NewRelicQuerySupplier.getBrokerMap();
             _brokerID = facets.asInt();
             _topic = null;
             _partition = -1;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicAdapterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicAdapterTest.java
@@ -151,8 +151,8 @@ public class NewRelicAdapterTest extends LocalServerTestBase {
 
     private static HttpEntity partitionResponse() {
         return new StringEntity("{\"data\":{\"actor\":{\"account\":{\"nrql\":{\"results\":[{\"facet\":"
-                + "[\"6\", \"test_topic1\", \"0\"], \"max.kafka_log_Log_Value_Size\":262.0}, "
-                + "{\"facet\":[\"5\", \"test_topic2\", \"14\"], \"max.kafka_log_Log_Value_Size\""
+                + "[\"6\", \"test_topic1\", \"0\"], \"max.partitionSize\":262.0}, "
+                + "{\"facet\":[\"5\", \"test_topic2\", \"14\"], \"max.partitionSize\""
                 + ":135.0}]}}}}}", StandardCharsets.UTF_8);
     }
 


### PR DESCRIPTION
The partition metrics map also needed to be updated so that the adapter could process the outputs properly. 