### PR TITLE
Add in config option for NewRelicQuerySupplier

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/DefaultNewRelicQuerySupplier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/DefaultNewRelicQuerySupplier.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.monitor.sampling.newrelic;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType;
@@ -15,9 +16,13 @@ import static com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricT
  * stats which are used by cruise control.
  */
 public final class DefaultNewRelicQuerySupplier implements NewRelicQuerySupplier {
-    private static final HashMap<String, RawMetricType> BROKER_METRICS = new HashMap<>();
-    private static final HashMap<String, RawMetricType> TOPIC_METRICS = new HashMap<>();
-    private static final HashMap<String, RawMetricType> PARTITION_METRICS = new HashMap<>();
+    private static final Map<String, RawMetricType> BROKER_METRICS = new HashMap<>();
+    private static final Map<String, RawMetricType> TOPIC_METRICS = new HashMap<>();
+    private static final Map<String, RawMetricType> PARTITION_METRICS = new HashMap<>();
+
+    private static final Map<String, RawMetricType> UNMODIFIABLE_BROKER_MAP = Collections.unmodifiableMap(BROKER_METRICS);
+    private static final Map<String, RawMetricType> UNMODIFIABLE_TOPIC_MAP = Collections.unmodifiableMap(TOPIC_METRICS);
+    private static final Map<String, RawMetricType> UNMODIFIABLE_PARTITION_MAP = Collections.unmodifiableMap(PARTITION_METRICS);
 
     private static final String BROKER_QUERY = "FROM KafkaBrokerStats "
             + "SELECT %s "
@@ -43,6 +48,7 @@ public final class DefaultNewRelicQuerySupplier implements NewRelicQuerySupplier
             + "SINCE 1 minute ago "
             + "LIMIT MAX";
 
+    @Override
     public String brokerQuery(String clusterName) {
         return brokerQueryFormat(generateFeatures(BROKER_METRICS), clusterName);
     }
@@ -51,6 +57,7 @@ public final class DefaultNewRelicQuerySupplier implements NewRelicQuerySupplier
         return String.format(BROKER_QUERY, select, clusterName);
     }
 
+    @Override
     public String topicQuery(String brokerSelect, String clusterName) {
         return topicQueryFormat(generateFeatures(TOPIC_METRICS), brokerSelect, clusterName);
     }
@@ -59,20 +66,24 @@ public final class DefaultNewRelicQuerySupplier implements NewRelicQuerySupplier
         return String.format(TOPIC_QUERY, select, clusterName, brokerSelect);
     }
 
+    @Override
     public String partitionQuery(String whereClause, String clusterName) {
         return String.format(PARTITION_QUERY, clusterName, whereClause);
     }
 
-    public Map<String, RawMetricType> getBrokerMap() {
-        return BROKER_METRICS;
+    @Override
+    public Map<String, RawMetricType> getUnmodifiableBrokerMap() {
+        return UNMODIFIABLE_BROKER_MAP;
     }
 
-    public Map<String, RawMetricType> getTopicMap() {
-        return TOPIC_METRICS;
+    @Override
+    public Map<String, RawMetricType> getUnmodifiableTopicMap() {
+        return UNMODIFIABLE_TOPIC_MAP;
     }
 
-    public Map<String, RawMetricType> getPartitionMap() {
-        return PARTITION_METRICS;
+    @Override
+    public Map<String, RawMetricType> getUnmodifiablePartitionMap() {
+        return UNMODIFIABLE_PARTITION_MAP;
     }
 
     /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/DefaultNewRelicQuerySupplier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/DefaultNewRelicQuerySupplier.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.monitor.sampling.newrelic;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType;
+
+import static com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType.*;
+
+/**
+ * Contains the NRQL queries which will output broker, topic, and partition level
+ * stats which are used by cruise control.
+ */
+public final class DefaultNewRelicQuerySupplier implements NewRelicQuerySupplier {
+    private static final HashMap<String, RawMetricType> BROKER_METRICS = new HashMap<>();
+    private static final HashMap<String, RawMetricType> TOPIC_METRICS = new HashMap<>();
+    private static final HashMap<String, RawMetricType> PARTITION_METRICS = new HashMap<>();
+
+    private static final String BROKER_QUERY = "FROM KafkaBrokerStats "
+            + "SELECT %s "
+            + "WHERE cluster = '%s' "
+            + "FACET broker "
+            + "SINCE 1 minute ago "
+            + "LIMIT MAX";
+
+    private static final String TOPIC_QUERY = "FROM KafkaBrokerTopicStats "
+            + "SELECT %s "
+            + "WHERE cluster = '%s' "
+            + "%s"
+            + "AND topic is NOT NULL "
+            + "FACET broker, topic "
+            + "SINCE 1 minute ago "
+            + "LIMIT MAX";
+
+    private static final String PARTITION_QUERY = "FROM KafkaPartitionSizeStats "
+            + "SELECT max(partitionSize) "
+            + "WHERE cluster = '%s' "
+            + "WHERE %s "
+            + "FACET broker, topic, partition "
+            + "SINCE 1 minute ago "
+            + "LIMIT MAX";
+
+    public String brokerQuery(String clusterName) {
+        return brokerQueryFormat(generateFeatures(BROKER_METRICS), clusterName);
+    }
+
+    private static String brokerQueryFormat(String select, String clusterName) {
+        return String.format(BROKER_QUERY, select, clusterName);
+    }
+
+    public String topicQuery(String brokerSelect, String clusterName) {
+        return topicQueryFormat(generateFeatures(TOPIC_METRICS), brokerSelect, clusterName);
+    }
+
+    private static String topicQueryFormat(String select, String brokerSelect, String clusterName) {
+        return String.format(TOPIC_QUERY, select, clusterName, brokerSelect);
+    }
+
+    public String partitionQuery(String whereClause, String clusterName) {
+        return String.format(PARTITION_QUERY, clusterName, whereClause);
+    }
+
+    public Map<String, RawMetricType> getBrokerMap() {
+        return BROKER_METRICS;
+    }
+
+    public Map<String, RawMetricType> getTopicMap() {
+        return TOPIC_METRICS;
+    }
+
+    public Map<String, RawMetricType> getPartitionMap() {
+        return PARTITION_METRICS;
+    }
+
+    /**
+     * Generates the sequence of SELECT features we want to use in our queries
+     * based on which metrics we are looking to collect in that query.
+     * @param metrics - List of queryLabels mapped to their metric types
+     * @return - Feature string of the format: "max(feature1), max(feature2), ... max(featureN)"
+     */
+    private static String generateFeatures(Map<String, RawMetricType> metrics) {
+        StringBuffer buffer = new StringBuffer();
+
+        // We want a comma on all but the last element so we will handle the last one separately
+        String[] metricLabels = metrics.keySet().toArray(new String [0]);
+        for (int i = 0; i < metricLabels.length - 1; i++) {
+            buffer.append(String.format("max(%s), ", metricLabels[i]));
+        }
+        // Add in last element without a comma or space
+        buffer.append(String.format("max(%s)", metricLabels[metricLabels.length - 1]));
+
+        return buffer.toString();
+    }
+
+    static {
+        // broker level metrics
+        BROKER_METRICS.put("bytesInPerSec", ALL_TOPIC_BYTES_IN);
+        BROKER_METRICS.put("bytesOutPerSec", ALL_TOPIC_BYTES_OUT);
+        BROKER_METRICS.put("replicationBytesInPerSec", ALL_TOPIC_REPLICATION_BYTES_IN);
+        BROKER_METRICS.put("replicationBytesOutPerSec", ALL_TOPIC_REPLICATION_BYTES_OUT);
+        BROKER_METRICS.put("totalFetchRequestsPerSec", ALL_TOPIC_FETCH_REQUEST_RATE);
+        BROKER_METRICS.put("totalProduceRequestsPerSec", ALL_TOPIC_PRODUCE_REQUEST_RATE);
+        BROKER_METRICS.put("messagesInPerSec", ALL_TOPIC_MESSAGES_IN_PER_SEC);
+        BROKER_METRICS.put("cpuTotalUtilizationPercentage / 100", BROKER_CPU_UTIL);
+        BROKER_METRICS.put("produceRequestsPerSec", BROKER_PRODUCE_REQUEST_RATE);
+        BROKER_METRICS.put("fetchConsumerRequestsPerSec", BROKER_CONSUMER_FETCH_REQUEST_RATE);
+        BROKER_METRICS.put("fetchFollowerRequestsPerSec", BROKER_FOLLOWER_FETCH_REQUEST_RATE);
+        BROKER_METRICS.put("requestQueueSize", BROKER_REQUEST_QUEUE_SIZE);
+        BROKER_METRICS.put("responseQueueSize", BROKER_RESPONSE_QUEUE_SIZE);
+        BROKER_METRICS.put("produceQueueTimeMaxMs", BROKER_PRODUCE_REQUEST_QUEUE_TIME_MS_MAX);
+        BROKER_METRICS.put("produceQueueTimeMeanMs", BROKER_PRODUCE_REQUEST_QUEUE_TIME_MS_MEAN);
+        BROKER_METRICS.put("produceQueueTime50thPercentileMs", BROKER_PRODUCE_REQUEST_QUEUE_TIME_MS_50TH);
+        BROKER_METRICS.put("produceQueueTime999thPercentileMs", BROKER_PRODUCE_REQUEST_QUEUE_TIME_MS_999TH);
+        BROKER_METRICS.put("fetchConsumerQueueTimeMaxMs", BROKER_CONSUMER_FETCH_REQUEST_QUEUE_TIME_MS_MAX);
+        BROKER_METRICS.put("fetchConsumerQueueTimeMeanMs", BROKER_CONSUMER_FETCH_REQUEST_QUEUE_TIME_MS_MEAN);
+        BROKER_METRICS.put("fetchConsumerQueueTime50thPercentileMs", BROKER_CONSUMER_FETCH_REQUEST_QUEUE_TIME_MS_50TH);
+        BROKER_METRICS.put("fetchConsumerQueueTime999thPercentileMs", BROKER_CONSUMER_FETCH_REQUEST_QUEUE_TIME_MS_999TH);
+        BROKER_METRICS.put("fetchFollowerQueueTimeMaxMs", BROKER_FOLLOWER_FETCH_REQUEST_QUEUE_TIME_MS_MAX);
+        BROKER_METRICS.put("fetchFollowerQueueTimeMeanMs", BROKER_FOLLOWER_FETCH_REQUEST_QUEUE_TIME_MS_MEAN);
+        BROKER_METRICS.put("fetchFollowerQueueTime50thPercentileMs", BROKER_FOLLOWER_FETCH_REQUEST_QUEUE_TIME_MS_50TH);
+        BROKER_METRICS.put("fetchFollowerQueueTime999thPercentileMs", BROKER_FOLLOWER_FETCH_REQUEST_QUEUE_TIME_MS_999TH);
+        BROKER_METRICS.put("produceLocalTimeMaxMs", BROKER_PRODUCE_LOCAL_TIME_MS_MAX);
+        BROKER_METRICS.put("produceLocalTimeMeanMs", BROKER_PRODUCE_LOCAL_TIME_MS_MEAN);
+        BROKER_METRICS.put("produceLocalTime50thPercentileMs", BROKER_PRODUCE_LOCAL_TIME_MS_50TH);
+        BROKER_METRICS.put("produceLocalTime999thPercentileMs", BROKER_PRODUCE_LOCAL_TIME_MS_999TH);
+        BROKER_METRICS.put("fetchConsumerLocalTimeMaxMs", BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_MAX);
+        BROKER_METRICS.put("fetchConsumerLocalTimeMeanMs", BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_MEAN);
+        BROKER_METRICS.put("fetchConsumerLocalTime50thPercentileMs", BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_50TH);
+        BROKER_METRICS.put("fetchConsumerLocalTime999thPercentileMs", BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_999TH);
+        BROKER_METRICS.put("fetchFollowerLocalTimeMaxMs", BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_MAX);
+        BROKER_METRICS.put("fetchFollowerLocalTimeMeanMs", BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_MEAN);
+        BROKER_METRICS.put("fetchFollowerLocalTime50thPercentileMs", BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_50TH);
+        BROKER_METRICS.put("fetchFollowerLocalTime999thPercentileMs", BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_999TH);
+        BROKER_METRICS.put("produceLatencyMaxMs", BROKER_PRODUCE_TOTAL_TIME_MS_MAX);
+        BROKER_METRICS.put("produceLatencyMeanMs", BROKER_PRODUCE_TOTAL_TIME_MS_MEAN);
+        BROKER_METRICS.put("produceLatency50thPercentileMs", BROKER_PRODUCE_TOTAL_TIME_MS_50TH);
+        BROKER_METRICS.put("produceLatency999thPercentileMs", BROKER_PRODUCE_TOTAL_TIME_MS_999TH);
+        BROKER_METRICS.put("fetchConsumerLatencyMaxMs", BROKER_CONSUMER_FETCH_TOTAL_TIME_MS_MAX);
+        BROKER_METRICS.put("fetchConsumerLatencyMeanMs", BROKER_CONSUMER_FETCH_TOTAL_TIME_MS_MEAN);
+        BROKER_METRICS.put("fetchConsumerLatency50thPercentileMs", BROKER_CONSUMER_FETCH_TOTAL_TIME_MS_50TH);
+        BROKER_METRICS.put("fetchConsumerLatency999thPercentileMs", BROKER_CONSUMER_FETCH_TOTAL_TIME_MS_999TH);
+        BROKER_METRICS.put("fetchFollowerLatencyMaxMs", BROKER_FOLLOWER_FETCH_TOTAL_TIME_MS_MAX);
+        BROKER_METRICS.put("fetchFollowerLatencyMeanMs", BROKER_FOLLOWER_FETCH_TOTAL_TIME_MS_MEAN);
+        BROKER_METRICS.put("fetchFollowerLatency50thPercentileMs", BROKER_FOLLOWER_FETCH_TOTAL_TIME_MS_50TH);
+        BROKER_METRICS.put("fetchFollowerLatency999thPercentileMs", BROKER_FOLLOWER_FETCH_TOTAL_TIME_MS_999TH);
+        BROKER_METRICS.put("logFlushOneMinuteRateMs", BROKER_LOG_FLUSH_RATE);
+        BROKER_METRICS.put("logFlushMaxMs", BROKER_LOG_FLUSH_TIME_MS_MAX);
+        BROKER_METRICS.put("logFlushMeanMs", BROKER_LOG_FLUSH_TIME_MS_MEAN);
+        BROKER_METRICS.put("logFlush50thPercentileMs", BROKER_LOG_FLUSH_TIME_MS_50TH);
+        BROKER_METRICS.put("logFlush999thPercentileMs", BROKER_LOG_FLUSH_TIME_MS_999TH);
+        BROKER_METRICS.put("requestHandlerAvgIdlePercent", BROKER_REQUEST_HANDLER_AVG_IDLE_PERCENT);
+
+        // topic level metrics
+        TOPIC_METRICS.put("bytesInPerSec", TOPIC_BYTES_IN);
+        TOPIC_METRICS.put("bytesOutPerSec", TOPIC_BYTES_OUT);
+        // We don't collect the following data on a topic level so I'm not including them
+        //TOPIC_METRICS.put("replicationBytesInPerSec", TOPIC_REPLICATION_BYTES_IN);
+        //TOPIC_METRICS.put("replicationBytesOutPerSec", TOPIC_REPLICATION_BYTES_OUT);
+        TOPIC_METRICS.put("totalFetchRequestsPerSec", TOPIC_FETCH_REQUEST_RATE);
+        TOPIC_METRICS.put("totalProduceRequestsPerSec", TOPIC_PRODUCE_REQUEST_RATE);
+        TOPIC_METRICS.put("messagesInPerSec", TOPIC_MESSAGES_IN_PER_SEC);
+
+        // partition level metrics
+        PARTITION_METRICS.put("partitionSize", PARTITION_SIZE);
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicQuerySupplier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicQuerySupplier.java
@@ -7,16 +7,71 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling.newrelic;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType;
 import java.util.Map;
 
+/**
+ *
+ */
 public interface NewRelicQuerySupplier {
+    /**
+     * Returns a NRQL query which will be used to acquire all the information
+     * related to brokers of this cluster that cruise control needs. The specific broker metrics
+     * that we need for cruise control are in the enum RawMetricType.
+     * @param clusterName - Name of the cluster that we are acquiring the broker metrics for
+     * @return - The actual NRQL query we can run to acquire the broker data.
+     */
     String brokerQuery(String clusterName);
 
+    /**
+     * Returns a NRQL query that will be used to acquire all the information
+     * related to topics in the specified brokers of this cluster that cruise control needs.
+     * The specific topic metrics that we need for cruise control are in the enum RawMetricType.
+     * Note that it is not necessary to acquire data for TOPIC_REPLICATION_BYTES_IN and
+     * TOPIC_REPLICATION_BYTES_OUT if this data is not being collected.
+     * @param brokerSelect - Brokers to select in the situation that there are more than
+     *                    NewRelicMetricSampler.MAX_SIZE unique topic/broker combinations in this cluster.
+     * @param clusterName - Name of the cluster that we are acquiring the topic metrics for
+     * @return - The actual NRQL query we can run to acquire information about the topics in the
+     *           specified brokers.
+     */
     String topicQuery(String brokerSelect, String clusterName);
 
+    /**
+     * Returns a NRQL query that will be used to acquire all the information related
+     * to the replicas in the specified topics (or broker and topic) combination of this cluster
+     * that cruise control needs. The specific partition metrics that we need for cruise control
+     * are in the enum RawMetricType.
+     * @param whereClause - Clause to select for replicas since it is typical for a cluster to hav
+     *                    more than NewRelicMetricSampler.MAX_SIZE unique replicas per topic/broker
+     *                    combinations.
+     * @param clusterName - Name of the cluster that we are acquiring the partition metrics for
+     * @return - The actual NRQL query we can run to acquire information about the replicas in the
+     *           specified whereClause. The query should output one value for each replica that we need.
+     */
     String partitionQuery(String whereClause, String clusterName);
 
-    Map<String, RawMetricType> getBrokerMap();
+    /**
+     * Getter for BrokerMap
+     * @return - Gets a map of String to RawMetricType which will be used to
+     *           look at a NRQL broker query output and map the output values
+     *           to different broker RawMetricTypes. This map should be unmodifiable and should
+     *           map to all possible broker query output types.
+     */
+    Map<String, RawMetricType> getUnmodifiableBrokerMap();
 
-    Map<String, RawMetricType> getTopicMap();
+    /**
+     * Getter for TopicMap
+     * @return - Gets a map of String to RawMetricType which will be used to
+     *           look at a NRQL topic query output and map the output values
+     *           to different topic RawMetricTypes. This map should be unmodifiable and should
+     *           map to all possible topic query output types.
+     */
+    Map<String, RawMetricType> getUnmodifiableTopicMap();
 
-    Map<String, RawMetricType> getPartitionMap();
+    /**
+     * Getter for PartitionMap
+     * @return - Gets a map of String to RawMetricType which will be used to
+     *           look at NRQL partition query output and map the output values
+     *           to different partition RawMetricTypes. This map should be unmodifiable and should
+     *           map to all possible partition query output types.
+     */
+    Map<String, RawMetricType> getUnmodifiablePartitionMap();
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicQuerySupplier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicQuerySupplier.java
@@ -4,170 +4,19 @@
 
 package com.linkedin.kafka.cruisecontrol.monitor.sampling.newrelic;
 
-import java.util.HashMap;
-import java.util.Map;
 import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType;
+import java.util.Map;
 
-import static com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType.*;
+public interface NewRelicQuerySupplier {
+    String brokerQuery(String clusterName);
 
-/**
- * Contains the NRQL queries which will output broker, topic, and partition level
- * stats which are used by cruise control.
- */
-public final class NewRelicQuerySupplier {
-    private NewRelicQuerySupplier() {
-        // Not called
-    }
+    String topicQuery(String brokerSelect, String clusterName);
 
-    private static final HashMap<String, RawMetricType> BROKER_METRICS = new HashMap<>();
-    private static final HashMap<String, RawMetricType> TOPIC_METRICS = new HashMap<>();
-    private static final HashMap<String, RawMetricType> PARTITION_METRICS = new HashMap<>();
+    String partitionQuery(String whereClause, String clusterName);
 
-    private static final String BROKER_QUERY = "FROM KafkaBrokerStats "
-            + "SELECT %s "
-            + "WHERE cluster = '%s' "
-            + "FACET broker "
-            + "SINCE 1 minute ago "
-            + "LIMIT MAX";
+    Map<String, RawMetricType> getBrokerMap();
 
-    private static final String TOPIC_QUERY = "FROM KafkaBrokerTopicStats "
-            + "SELECT %s "
-            + "WHERE cluster = '%s' "
-            + "%s"
-            + "AND topic is NOT NULL "
-            + "FACET broker, topic "
-            + "SINCE 1 minute ago "
-            + "LIMIT MAX";
+    Map<String, RawMetricType> getTopicMap();
 
-    private static final String PARTITION_QUERY = "FROM KafkaPartitionSizeStats "
-            + "SELECT max(partitionSize) "
-            + "WHERE cluster = '%s' "
-            + "WHERE %s "
-            + "FACET broker, topic, partition "
-            + "SINCE 1 minute ago "
-            + "LIMIT MAX";
-
-    public static String brokerQuery(String clusterName) {
-        return brokerQueryFormat(generateFeatures(BROKER_METRICS), clusterName);
-    }
-
-    private static String brokerQueryFormat(String select, String clusterName) {
-        return String.format(BROKER_QUERY, select, clusterName);
-    }
-
-    public static String topicQuery(String brokerSelect, String clusterName) {
-        return topicQueryFormat(generateFeatures(TOPIC_METRICS), brokerSelect, clusterName);
-    }
-
-    private static String topicQueryFormat(String select, String brokerSelect, String clusterName) {
-        return String.format(TOPIC_QUERY, select, clusterName, brokerSelect);
-    }
-
-    public static String partitionQuery(String whereClause, String clusterName) {
-        return String.format(PARTITION_QUERY, clusterName, whereClause);
-    }
-
-    public static Map<String, RawMetricType> getBrokerMap() {
-        return BROKER_METRICS;
-    }
-
-    public static Map<String, RawMetricType> getTopicMap() {
-        return TOPIC_METRICS;
-    }
-
-    public static Map<String, RawMetricType> getPartitionMap() {
-        return PARTITION_METRICS;
-    }
-
-    /**
-     * Generates the sequence of SELECT features we want to use in our queries
-     * based on which metrics we are looking to collect in that query.
-     * @param metrics - List of queryLabels mapped to their metric types
-     * @return - Feature string of the format: "max(feature1), max(feature2), ... max(featureN)"
-     */
-    private static String generateFeatures(Map<String, RawMetricType> metrics) {
-        StringBuffer buffer = new StringBuffer();
-
-        // We want a comma on all but the last element so we will handle the last one separately
-        String[] metricLabels = metrics.keySet().toArray(new String [0]);
-        for (int i = 0; i < metricLabels.length - 1; i++) {
-            buffer.append(String.format("max(%s), ", metricLabels[i]));
-        }
-        // Add in last element without a comma or space
-        buffer.append(String.format("max(%s)", metricLabels[metricLabels.length - 1]));
-
-        return buffer.toString();
-    }
-
-    static {
-        // broker level metrics
-        BROKER_METRICS.put("bytesInPerSec", ALL_TOPIC_BYTES_IN);
-        BROKER_METRICS.put("bytesOutPerSec", ALL_TOPIC_BYTES_OUT);
-        BROKER_METRICS.put("replicationBytesInPerSec", ALL_TOPIC_REPLICATION_BYTES_IN);
-        BROKER_METRICS.put("replicationBytesOutPerSec", ALL_TOPIC_REPLICATION_BYTES_OUT);
-        BROKER_METRICS.put("totalFetchRequestsPerSec", ALL_TOPIC_FETCH_REQUEST_RATE);
-        BROKER_METRICS.put("totalProduceRequestsPerSec", ALL_TOPIC_PRODUCE_REQUEST_RATE);
-        BROKER_METRICS.put("messagesInPerSec", ALL_TOPIC_MESSAGES_IN_PER_SEC);
-        BROKER_METRICS.put("cpuTotalUtilizationPercentage / 100", BROKER_CPU_UTIL);
-        BROKER_METRICS.put("produceRequestsPerSec", BROKER_PRODUCE_REQUEST_RATE);
-        BROKER_METRICS.put("fetchConsumerRequestsPerSec", BROKER_CONSUMER_FETCH_REQUEST_RATE);
-        BROKER_METRICS.put("fetchFollowerRequestsPerSec", BROKER_FOLLOWER_FETCH_REQUEST_RATE);
-        BROKER_METRICS.put("requestQueueSize", BROKER_REQUEST_QUEUE_SIZE);
-        BROKER_METRICS.put("responseQueueSize", BROKER_RESPONSE_QUEUE_SIZE);
-        BROKER_METRICS.put("produceQueueTimeMaxMs", BROKER_PRODUCE_REQUEST_QUEUE_TIME_MS_MAX);
-        BROKER_METRICS.put("produceQueueTimeMeanMs", BROKER_PRODUCE_REQUEST_QUEUE_TIME_MS_MEAN);
-        BROKER_METRICS.put("produceQueueTime50thPercentileMs", BROKER_PRODUCE_REQUEST_QUEUE_TIME_MS_50TH);
-        BROKER_METRICS.put("produceQueueTime999thPercentileMs", BROKER_PRODUCE_REQUEST_QUEUE_TIME_MS_999TH);
-        BROKER_METRICS.put("fetchConsumerQueueTimeMaxMs", BROKER_CONSUMER_FETCH_REQUEST_QUEUE_TIME_MS_MAX);
-        BROKER_METRICS.put("fetchConsumerQueueTimeMeanMs", BROKER_CONSUMER_FETCH_REQUEST_QUEUE_TIME_MS_MEAN);
-        BROKER_METRICS.put("fetchConsumerQueueTime50thPercentileMs", BROKER_CONSUMER_FETCH_REQUEST_QUEUE_TIME_MS_50TH);
-        BROKER_METRICS.put("fetchConsumerQueueTime999thPercentileMs", BROKER_CONSUMER_FETCH_REQUEST_QUEUE_TIME_MS_999TH);
-        BROKER_METRICS.put("fetchFollowerQueueTimeMaxMs", BROKER_FOLLOWER_FETCH_REQUEST_QUEUE_TIME_MS_MAX);
-        BROKER_METRICS.put("fetchFollowerQueueTimeMeanMs", BROKER_FOLLOWER_FETCH_REQUEST_QUEUE_TIME_MS_MEAN);
-        BROKER_METRICS.put("fetchFollowerQueueTime50thPercentileMs", BROKER_FOLLOWER_FETCH_REQUEST_QUEUE_TIME_MS_50TH);
-        BROKER_METRICS.put("fetchFollowerQueueTime999thPercentileMs", BROKER_FOLLOWER_FETCH_REQUEST_QUEUE_TIME_MS_999TH);
-        BROKER_METRICS.put("produceLocalTimeMaxMs", BROKER_PRODUCE_LOCAL_TIME_MS_MAX);
-        BROKER_METRICS.put("produceLocalTimeMeanMs", BROKER_PRODUCE_LOCAL_TIME_MS_MEAN);
-        BROKER_METRICS.put("produceLocalTime50thPercentileMs", BROKER_PRODUCE_LOCAL_TIME_MS_50TH);
-        BROKER_METRICS.put("produceLocalTime999thPercentileMs", BROKER_PRODUCE_LOCAL_TIME_MS_999TH);
-        BROKER_METRICS.put("fetchConsumerLocalTimeMaxMs", BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_MAX);
-        BROKER_METRICS.put("fetchConsumerLocalTimeMeanMs", BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_MEAN);
-        BROKER_METRICS.put("fetchConsumerLocalTime50thPercentileMs", BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_50TH);
-        BROKER_METRICS.put("fetchConsumerLocalTime999thPercentileMs", BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_999TH);
-        BROKER_METRICS.put("fetchFollowerLocalTimeMaxMs", BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_MAX);
-        BROKER_METRICS.put("fetchFollowerLocalTimeMeanMs", BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_MEAN);
-        BROKER_METRICS.put("fetchFollowerLocalTime50thPercentileMs", BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_50TH);
-        BROKER_METRICS.put("fetchFollowerLocalTime999thPercentileMs", BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_999TH);
-        BROKER_METRICS.put("produceLatencyMaxMs", BROKER_PRODUCE_TOTAL_TIME_MS_MAX);
-        BROKER_METRICS.put("produceLatencyMeanMs", BROKER_PRODUCE_TOTAL_TIME_MS_MEAN);
-        BROKER_METRICS.put("produceLatency50thPercentileMs", BROKER_PRODUCE_TOTAL_TIME_MS_50TH);
-        BROKER_METRICS.put("produceLatency999thPercentileMs", BROKER_PRODUCE_TOTAL_TIME_MS_999TH);
-        BROKER_METRICS.put("fetchConsumerLatencyMaxMs", BROKER_CONSUMER_FETCH_TOTAL_TIME_MS_MAX);
-        BROKER_METRICS.put("fetchConsumerLatencyMeanMs", BROKER_CONSUMER_FETCH_TOTAL_TIME_MS_MEAN);
-        BROKER_METRICS.put("fetchConsumerLatency50thPercentileMs", BROKER_CONSUMER_FETCH_TOTAL_TIME_MS_50TH);
-        BROKER_METRICS.put("fetchConsumerLatency999thPercentileMs", BROKER_CONSUMER_FETCH_TOTAL_TIME_MS_999TH);
-        BROKER_METRICS.put("fetchFollowerLatencyMaxMs", BROKER_FOLLOWER_FETCH_TOTAL_TIME_MS_MAX);
-        BROKER_METRICS.put("fetchFollowerLatencyMeanMs", BROKER_FOLLOWER_FETCH_TOTAL_TIME_MS_MEAN);
-        BROKER_METRICS.put("fetchFollowerLatency50thPercentileMs", BROKER_FOLLOWER_FETCH_TOTAL_TIME_MS_50TH);
-        BROKER_METRICS.put("fetchFollowerLatency999thPercentileMs", BROKER_FOLLOWER_FETCH_TOTAL_TIME_MS_999TH);
-        BROKER_METRICS.put("logFlushOneMinuteRateMs", BROKER_LOG_FLUSH_RATE);
-        BROKER_METRICS.put("logFlushMaxMs", BROKER_LOG_FLUSH_TIME_MS_MAX);
-        BROKER_METRICS.put("logFlushMeanMs", BROKER_LOG_FLUSH_TIME_MS_MEAN);
-        BROKER_METRICS.put("logFlush50thPercentileMs", BROKER_LOG_FLUSH_TIME_MS_50TH);
-        BROKER_METRICS.put("logFlush999thPercentileMs", BROKER_LOG_FLUSH_TIME_MS_999TH);
-        BROKER_METRICS.put("requestHandlerAvgIdlePercent", BROKER_REQUEST_HANDLER_AVG_IDLE_PERCENT);
-
-        // topic level metrics
-        TOPIC_METRICS.put("bytesInPerSec", TOPIC_BYTES_IN);
-        TOPIC_METRICS.put("bytesOutPerSec", TOPIC_BYTES_OUT);
-        // We don't collect the following data on a topic level so I'm not including them
-        //TOPIC_METRICS.put("replicationBytesInPerSec", TOPIC_REPLICATION_BYTES_IN);
-        //TOPIC_METRICS.put("replicationBytesOutPerSec", TOPIC_REPLICATION_BYTES_OUT);
-        TOPIC_METRICS.put("totalFetchRequestsPerSec", TOPIC_FETCH_REQUEST_RATE);
-        TOPIC_METRICS.put("totalProduceRequestsPerSec", TOPIC_PRODUCE_REQUEST_RATE);
-        TOPIC_METRICS.put("messagesInPerSec", TOPIC_MESSAGES_IN_PER_SEC);
-
-        // partition level metrics
-        PARTITION_METRICS.put("partitionSize", PARTITION_SIZE);
-    }
+    Map<String, RawMetricType> getPartitionMap();
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicQuerySupplier.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicQuerySupplier.java
@@ -8,7 +8,8 @@ import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType;
 import java.util.Map;
 
 /**
- *
+ * Supplies the different NRQL queries needed to be run in order to acquire
+ * the necessary broker, topic, and partition level cruise control metrics from NRDB.
  */
 public interface NewRelicQuerySupplier {
     /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/model/NewRelicQueryResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/model/NewRelicQueryResult.java
@@ -50,6 +50,12 @@ public class NewRelicQueryResult {
 
     private final Map<RawMetricType, Double> _results = new HashMap<>();
 
+    private static NewRelicQuerySupplier _querySupplier;
+
+    public static void setupQuerySupplier(NewRelicQuerySupplier querySupplier) {
+        _querySupplier = querySupplier;
+    }
+
     /**
      * Takes a JSON result which represents one of the results from a NRQL query,
      * figures out which type of query it is (broker, topic, or partition),
@@ -71,13 +77,13 @@ public class NewRelicQueryResult {
             _topic = facets.get(1).asText();
             if (facets.has(2)) {
                 _partition = facets.get(2).asInt();
-                valueToMetricMap = NewRelicQuerySupplier.getPartitionMap();
+                valueToMetricMap = _querySupplier.getPartitionMap();
             } else {
                 _partition = -1;
-                valueToMetricMap = NewRelicQuerySupplier.getTopicMap();
+                valueToMetricMap = _querySupplier.getTopicMap();
             }
         } else {
-            valueToMetricMap = NewRelicQuerySupplier.getBrokerMap();
+            valueToMetricMap = _querySupplier.getBrokerMap();
             _brokerID = facets.asInt();
             _topic = null;
             _partition = -1;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/model/NewRelicQueryResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/model/NewRelicQueryResult.java
@@ -77,13 +77,13 @@ public class NewRelicQueryResult {
             _topic = facets.get(1).asText();
             if (facets.has(2)) {
                 _partition = facets.get(2).asInt();
-                valueToMetricMap = _querySupplier.getPartitionMap();
+                valueToMetricMap = _querySupplier.getUnmodifiablePartitionMap();
             } else {
                 _partition = -1;
-                valueToMetricMap = _querySupplier.getTopicMap();
+                valueToMetricMap = _querySupplier.getUnmodifiableTopicMap();
             }
         } else {
-            valueToMetricMap = _querySupplier.getBrokerMap();
+            valueToMetricMap = _querySupplier.getUnmodifiableBrokerMap();
             _brokerID = facets.asInt();
             _topic = null;
             _partition = -1;

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/DefaultNewRelicQuerySupplierTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/DefaultNewRelicQuerySupplierTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.monitor.sampling.newrelic;
+
+import com.linkedin.kafka.cruisecontrol.metricsreporter.metric.RawMetricType;
+import org.junit.Test;
+import java.util.Map;
+
+public class DefaultNewRelicQuerySupplierTest {
+    private NewRelicQuerySupplier _querySupplier = new DefaultNewRelicQuerySupplier();
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnmodifiableBrokerMap() {
+        Map<String, RawMetricType> brokerMap = _querySupplier.getUnmodifiableBrokerMap();
+        brokerMap.put("Test", RawMetricType.ALL_TOPIC_BYTES_IN);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnmodifiableTopicMap() {
+        Map<String, RawMetricType> brokerMap = _querySupplier.getUnmodifiableTopicMap();
+        brokerMap.put("Test", RawMetricType.TOPIC_BYTES_IN);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnmodifiablePartitionMap() {
+        Map<String, RawMetricType> brokerMap = _querySupplier.getUnmodifiablePartitionMap();
+        brokerMap.put("Test", RawMetricType.PARTITION_SIZE);
+    }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicAdapterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicAdapterTest.java
@@ -14,6 +14,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.localserver.LocalServerTestBase;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpRequestHandler;
+import org.junit.Before;
 import org.junit.Test;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -28,9 +29,19 @@ import static org.junit.Assert.assertTrue;
 public class NewRelicAdapterTest extends LocalServerTestBase {
     private static String CLUSTER_NAME = "kafka-test-cluster";
 
+    private NewRelicQuerySupplier _querySupplier = new DefaultNewRelicQuerySupplier();
+
+    /**
+     * Set up mocks
+     */
+    @Before
+    public void setUpQueryResult() {
+        NewRelicQueryResult.setupQuerySupplier(_querySupplier);
+    }
+
     @Test
     public void testBrokerQuery() throws Exception {
-        String query = NewRelicQuerySupplier.brokerQuery(CLUSTER_NAME);
+        String query = _querySupplier.brokerQuery(CLUSTER_NAME);
 
         this.serverBootstrap.registerHandler("*", new HttpRequestHandler() {
             @Override public void handle(HttpRequest request, HttpResponse response, HttpContext context) {
@@ -74,7 +85,7 @@ public class NewRelicAdapterTest extends LocalServerTestBase {
 
     @Test
     public void testTopicQuery() throws Exception {
-        String query = NewRelicQuerySupplier.topicQuery("", CLUSTER_NAME);
+        String query = _querySupplier.topicQuery("", CLUSTER_NAME);
 
         this.serverBootstrap.registerHandler("*", new HttpRequestHandler() {
             @Override public void handle(HttpRequest request, HttpResponse response, HttpContext context) {
@@ -117,7 +128,7 @@ public class NewRelicAdapterTest extends LocalServerTestBase {
 
     @Test
     public void testPartitionQuery() throws Exception {
-        String query = NewRelicQuerySupplier.partitionQuery("TestTopic", CLUSTER_NAME);
+        String query = _querySupplier.partitionQuery("TestTopic", CLUSTER_NAME);
 
         this.serverBootstrap.registerHandler("*", new HttpRequestHandler() {
             @Override public void handle(HttpRequest request, HttpResponse response, HttpContext context) {
@@ -158,7 +169,7 @@ public class NewRelicAdapterTest extends LocalServerTestBase {
 
     @Test(expected = IOException.class)
     public void testFailureResponseWith403Code() throws Exception {
-        String query = NewRelicQuerySupplier.brokerQuery(CLUSTER_NAME);
+        String query = _querySupplier.brokerQuery(CLUSTER_NAME);
 
         this.serverBootstrap.registerHandler("*", new HttpRequestHandler() {
             @Override public void handle(HttpRequest request, HttpResponse response, HttpContext context) {
@@ -176,7 +187,7 @@ public class NewRelicAdapterTest extends LocalServerTestBase {
 
     @Test(expected = IOException.class)
     public void testEmptyResponse() throws Exception {
-        String query = NewRelicQuerySupplier.brokerQuery(CLUSTER_NAME);
+        String query = _querySupplier.brokerQuery(CLUSTER_NAME);
 
         this.serverBootstrap.registerHandler("*", new HttpRequestHandler() {
             @Override public void handle(HttpRequest request, HttpResponse response, HttpContext context) {
@@ -195,7 +206,7 @@ public class NewRelicAdapterTest extends LocalServerTestBase {
 
     @Test(expected = IOException.class)
     public void testInvalidJSONResponse() throws Exception {
-        String query = NewRelicQuerySupplier.brokerQuery(CLUSTER_NAME);
+        String query = _querySupplier.brokerQuery(CLUSTER_NAME);
 
         this.serverBootstrap.registerHandler("*", new HttpRequestHandler() {
             @Override public void handle(HttpRequest request, HttpResponse response, HttpContext context) {
@@ -216,7 +227,7 @@ public class NewRelicAdapterTest extends LocalServerTestBase {
     // new metrics are added which will be the case given that the size of results is 0
     @Test
     public void testEmptyResults() throws Exception {
-        String query = NewRelicQuerySupplier.brokerQuery(CLUSTER_NAME);
+        String query = _querySupplier.brokerQuery(CLUSTER_NAME);
 
         this.serverBootstrap.registerHandler("*", new HttpRequestHandler() {
             @Override public void handle(HttpRequest request, HttpResponse response, HttpContext context) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicMetricSamplerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicMetricSamplerTest.java
@@ -60,6 +60,8 @@ public class NewRelicMetricSamplerTest {
 
     private static String CLUSTER_NAME = "kafka-test-cluster";
 
+    private NewRelicQuerySupplier _querySupplier = new DefaultNewRelicQuerySupplier();
+
     /**
      * Set up mocks
      */
@@ -276,7 +278,7 @@ public class NewRelicMetricSamplerTest {
     private void setupNewRelicAdapterMock(List<NewRelicQueryResult> brokerResults,
                                           List<NewRelicQueryResult> topicResults,
                                           List<NewRelicQueryResult> partitionResults) throws Exception {
-            expect(_newRelicAdapter.runQuery(eq(NewRelicQuerySupplier.brokerQuery(CLUSTER_NAME))))
+            expect(_newRelicAdapter.runQuery(eq(_querySupplier.brokerQuery(CLUSTER_NAME))))
                     .andReturn(brokerResults);
 
             String beforeTopicRegex = String.format("FROM KafkaBrokerTopicStats SELECT max\\(messagesInPerSec\\), "
@@ -309,7 +311,7 @@ public class NewRelicMetricSamplerTest {
 
     private void setupNewRelicIllegalStateMock(List<NewRelicQueryResult> brokerResults,
                                                    List<NewRelicQueryResult> topicResults) throws Exception {
-        expect(_newRelicAdapter.runQuery(eq(NewRelicQuerySupplier.brokerQuery(CLUSTER_NAME))))
+        expect(_newRelicAdapter.runQuery(eq(_querySupplier.brokerQuery(CLUSTER_NAME))))
                 .andReturn(brokerResults);
 
         String beforeTopicRegex = String.format("FROM KafkaBrokerTopicStats SELECT max\\(messagesInPerSec\\), "

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicMetricSamplerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/newrelic/NewRelicMetricSamplerTest.java
@@ -511,17 +511,17 @@ public class NewRelicMetricSamplerTest {
         }
 
         @Override
-        public Map<String, RawMetricType> getBrokerMap() {
+        public Map<String, RawMetricType> getUnmodifiableBrokerMap() {
             return new HashMap<>();
         }
 
         @Override
-        public Map<String, RawMetricType> getTopicMap() {
+        public Map<String, RawMetricType> getUnmodifiableTopicMap() {
             return new HashMap<>();
         }
 
         @Override
-        public Map<String, RawMetricType> getPartitionMap() {
+        public Map<String, RawMetricType> getUnmodifiablePartitionMap() {
             return new HashMap<>();
         }
     }


### PR DESCRIPTION
Created a NewRelicQuerySupplier interface with the current query supplier being used becoming the DefaultNewRelicQuerySupplier. Added the option to input a different query supplier into the config if needed as long as that config implements NewRelicQuerySupplier. 

This should make it easier for anyone who isn't using the exact same naming conventions as us to use the NewRelicMetricSampler because it will allow them to create their own NewRelicQuerySupplier. 

Finally I also just added tests to make sure that the configuration was working properly and that we stick to the default when it isn't passed in. 