### PR TITLE
Optimizations for TopicLeadershipDistributionGoal

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicLeadershipDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicLeadershipDistributionGoal.java
@@ -60,7 +60,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
     private boolean _shouldSkipPerRackPhase = false;
 
     private Set<String> _allowedTopics;
-    private Set<Integer> _allowedBrokerIds;
+    private Set<Broker> _allowedBrokers;
 
     private final Map<String, Integer> _targetNumLeadReplicasPerRackByTopic;
     private final Map<String, Map<String, Integer>> _numLeadReplicasByTopicByRackId;
@@ -125,7 +125,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
         if (actionType.equals(ActionType.LEADERSHIP_MOVEMENT)
                 || actionType.equals(ActionType.INTER_BROKER_REPLICA_MOVEMENT)
                 || actionType.equals(ActionType.INTER_BROKER_REPLICA_SWAP)) {
-            LeadershipCounts counts = new LeadershipCounts(clusterModel, _allowedBrokerIds, topic);
+            LeadershipCounts counts = new LeadershipCounts(clusterModel, _allowedBrokers, topic);
 
             if (replica.isLeader()) {
                 counts.decrementCount(sourceBroker);
@@ -143,7 +143,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
                     // Destination replica does not exist so this is definitely not a valid move.
                     return ActionAcceptance.REPLICA_REJECT;
                 } else if (otherReplica.isLeader()) {
-                    LeadershipCounts otherTopicCounts = new LeadershipCounts(clusterModel, _allowedBrokerIds, otherTopic);
+                    LeadershipCounts otherTopicCounts = new LeadershipCounts(clusterModel, _allowedBrokers, otherTopic);
 
                     otherTopicCounts.decrementCount(destinationBroker);
                     otherTopicCounts.incrementCount(sourceBroker);
@@ -167,8 +167,8 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
         private final Map<Rack, Integer> _countsByRack;
         private final Map<Broker, Integer> _countsByBroker;
 
-        private LeadershipCounts(ClusterModel clusterModel, Set<Integer> allowedBrokerIds, String topic) {
-            _allowedBrokers = allowedBrokerIds.stream().map(clusterModel::broker).collect(Collectors.toSet());
+        private LeadershipCounts(ClusterModel clusterModel, Set<Broker> allowedBrokers, String topic) {
+            _allowedBrokers = allowedBrokers;
             _allowedRacks = _allowedBrokers.stream().map(Broker::rack).collect(Collectors.toSet());
 
             _countsByRack = clusterModel.getNumLeadReplicasByRack(topic);
@@ -255,7 +255,6 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
                     Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
 
                     return isTopicBalancedPerRack(
-                            clusterModel,
                             action.topic(),
                             sourceBroker.rack().id(),
                             destinationBroker.rack().id());
@@ -287,12 +286,11 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
         }
 
         Set<Integer> excludedBrokers = optimizationOptions.excludedBrokersForLeadership();
-        _allowedBrokerIds = clusterModel.aliveBrokers().stream()
-                .map(Broker::id)
-                .filter(b -> !excludedBrokers.contains(b))
+        _allowedBrokers = clusterModel.aliveBrokers().stream()
+                .filter(b -> !excludedBrokers.contains(b.id()))
                 .collect(Collectors.toCollection(HashSet::new));
 
-        if (_allowedBrokerIds.isEmpty()) {
+        if (_allowedBrokers.isEmpty()) {
             logAndThrowOptimizationFailureException("Cannot take any action as all alive brokers are excluded from leadership.");
         }
 
@@ -303,8 +301,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
 
         Set<Rack> racks = new HashSet<>();
 
-        for (Integer brokerId : _allowedBrokerIds) {
-            Broker broker = clusterModel.broker(brokerId);
+        for (Broker broker : _allowedBrokers) {
             racks.add(broker.rack());
         }
 
@@ -317,7 +314,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
             int targetNumLeadReplicasPerRack = Math.floorDiv(numLeadReplicas, racks.size());
             _targetNumLeadReplicasPerRackByTopic.put(topic, targetNumLeadReplicasPerRack);
 
-            int targetNumLeadReplicasPerBroker = Math.floorDiv(numLeadReplicas, _allowedBrokerIds.size());
+            int targetNumLeadReplicasPerBroker = Math.floorDiv(numLeadReplicas, _allowedBrokers.size());
             _targetNumLeadReplicasPerBrokerByTopic.put(topic, targetNumLeadReplicasPerBroker);
 
             Map<String, Integer> numLeadReplicasPerRack = new HashMap<>();
@@ -358,7 +355,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
                 boolean isBalancedPerRack = true;
 
                 for (String topic : _allowedTopics) {
-                    if (!isTopicBalancedPerRack(clusterModel, topic)) {
+                    if (!isTopicBalancedPerRack(topic)) {
                         isBalancedPerRack = false;
                     }
                 }
@@ -396,8 +393,8 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
                 case PER_RACK:
                     int targetPerRack = _targetNumLeadReplicasPerRackByTopic.get(topic);
 
-                    Set<String> rackIds = _allowedBrokerIds.stream()
-                            .map(b -> clusterModel.broker(b).rack().id())
+                    Set<String> rackIds = _allowedBrokers.stream()
+                            .map(b -> b.rack().id())
                             .collect(Collectors.toSet());
 
                     for (String rackId : rackIds) {
@@ -408,8 +405,8 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
                 case PER_BROKER:
                     int targetPerBroker = _targetNumLeadReplicasPerBrokerByTopic.get(topic);
 
-                    for (int brokerId : _allowedBrokerIds) {
-                        int count = _numLeadReplicasByTopicByBrokerId.get(topic).getOrDefault(brokerId, 0);
+                    for (Broker broker : _allowedBrokers) {
+                        int count = _numLeadReplicasByTopicByBrokerId.get(topic).getOrDefault(broker.id(), 0);
                         totalDelta += Math.abs(targetPerBroker - count);
                     }
                     break;
@@ -424,7 +421,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
             for (String topic : _allowedTopics) {
                 switch (_rebalancePhase) {
                     case PER_RACK:
-                        if (!isTopicBalancedPerRack(clusterModel, topic)) {
+                        if (!isTopicBalancedPerRack(topic)) {
                             s.append(prettyPrintedLeadershipDistributionByRack(clusterModel, topic));
                         }
                         break;
@@ -450,7 +447,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
             ClusterModel clusterModel,
             Set<Goal> optimizedGoals,
             OptimizationOptions optimizationOptions) throws OptimizationFailureException {
-        if (!_allowedBrokerIds.contains(broker.id())) {
+        if (!_allowedBrokers.contains(broker)) {
             return;
         }
 
@@ -463,7 +460,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
                 case PER_RACK:
                     LOG.debug("Re-balancing for broker {} in rack {} and topic {}", broker.id(), broker.rack().id(), topic);
 
-                    if (!isTopicBalancedPerRack(clusterModel, topic)) {
+                    if (!isTopicBalancedPerRack(topic)) {
                         int numLeadReplicasInRack = _numLeadReplicasByTopicByRackId
                                 .get(topic)
                                 .getOrDefault(broker.rack().id(), 0);
@@ -504,15 +501,14 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    private boolean isTopicBalancedPerRack(ClusterModel clusterModel, String topic) {
-        return isTopicBalancedPerRack(clusterModel, topic, null, null);
+    private boolean isTopicBalancedPerRack(String topic) {
+        return isTopicBalancedPerRack(topic, null, null);
     }
 
     /**
      * This method works similarly to {@link #isTopicBalancedPerBroker(String topic)} but on a per-rack basis instead
      * of a per-broker basis.
      *
-     * @param clusterModel {@link ClusterModel}
      * @param topic the topic to check
      * @param sourceRackId if considering a proposed action, this is the rack the lead replica is moving from (null if
      *                     not considering a proposed action)
@@ -523,15 +519,14 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
      * @see #isTopicBalancedPerBroker(String)
      */
     private boolean isTopicBalancedPerRack(
-            ClusterModel clusterModel,
             String topic,
             String sourceRackId,
             String destinationRackId) {
         Map<String, Integer> numLeadReplicasByRackId = _numLeadReplicasByTopicByRackId.get(topic);
         Integer target = _targetNumLeadReplicasPerRackByTopic.get(topic);
 
-        Set<String> rackIds = _allowedBrokerIds.stream()
-                .map(b -> clusterModel.broker(b).rack().id())
+        Set<String> rackIds = _allowedBrokers.stream()
+                .map(b -> b.rack().id())
                 .collect(Collectors.toSet());
 
         for (String rackId : rackIds) {
@@ -567,8 +562,8 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
         Map<Integer, Integer> numLeadReplicasByBrokerId = _numLeadReplicasByTopicByBrokerId.get(topic);
         int target = _targetNumLeadReplicasPerBrokerByTopic.get(topic);
 
-        for (int brokerId : _allowedBrokerIds) {
-            int numLeadReplicas = numLeadReplicasByBrokerId.getOrDefault(brokerId, 0);
+        for (Broker broker : _allowedBrokers) {
+            int numLeadReplicas = numLeadReplicasByBrokerId.getOrDefault(broker.id(), 0);
 
             if (numLeadReplicas < target || numLeadReplicas > target + 1) {
                 return false;
@@ -673,8 +668,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
                 Set<Broker> primaryCandidates = new HashSet<>();
                 Set<Broker> secondaryCandidates = new HashSet<>();
 
-                for (int brokerId : _allowedBrokerIds) {
-                    Broker broker = clusterModel.broker(brokerId);
+                for (Broker broker : _allowedBrokers) {
                     int numLeadReplicasInRack = numLeadReplicasByRackId.getOrDefault(broker.rack().id(), 0);
 
                     if (numLeadReplicasInRack < targetNumLeadReplicasPerRack) {
@@ -727,7 +721,7 @@ public class TopicLeadershipDistributionGoal extends AbstractGoal {
         Map<Integer, Integer> numLeadReplicasByBrokerId = _numLeadReplicasByTopicByBrokerId.get(topic);
 
         return clusterModel.aliveBrokers().stream()
-                .filter(b -> _allowedBrokerIds.contains(b.id()))
+                .filter(b -> _allowedBrokers.contains(b))
                 .filter(b -> {
                     int numLeadReplicas = numLeadReplicasByBrokerId.getOrDefault(b.id(), 0);
                     return onTarget ? numLeadReplicas == target : numLeadReplicas < target;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -36,6 +36,7 @@ import com.linkedin.kafka.cruisecontrol.monitor.sampling.holder.PartitionMetricS
 import com.linkedin.kafka.cruisecontrol.monitor.task.LoadMonitorTaskRunner;
 import com.linkedin.kafka.cruisecontrol.servlet.response.stats.BrokerStats;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -394,6 +395,8 @@ public class LoadMonitor {
     _clusterModelSemaphore.acquire();
     _acquiredClusterModelSemaphore.set(true);
     step.done();
+    LOG.info("Cluster model lock acquired:");
+    LOG.info(Arrays.toString(Thread.currentThread().getStackTrace()));
     return new AutoCloseableSemaphore();
   }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/TopicLeadershipDistributionGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/TopicLeadershipDistributionGoalTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+package com.linkedin.kafka.cruisecontrol.analyzer;
+
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicLeadershipDistributionGoal;
+import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
+import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.Partition;
+import com.linkedin.kafka.cruisecontrol.model.Replica;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
+import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC0;
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC1;
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC2;
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.TOPIC3;
+import static com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig.ZOOKEEPER_CONNECT_CONFIG;
+import static com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class TopicLeadershipDistributionGoalTest {
+
+    private static final int NUM_RACKS = 3;
+    private static final int NUM_BROKERS = 6;
+
+    @Test
+    public void testOptimize() throws KafkaCruiseControlException {
+        ClusterModel clusterModel = generateClusterModel();
+
+        Goal goal = initializeGoal(new TopicLeadershipDistributionGoal());
+        goal.optimize(
+                clusterModel,
+                Collections.emptySet(),
+                new OptimizationOptions(Collections.emptySet(), Collections.emptySet(), Collections.emptySet()));
+
+        Map<String, List<Partition>> partitionsByTopic = clusterModel.getPartitionsByTopic();
+
+        for (String topic : Arrays.asList(TOPIC0, TOPIC1, TOPIC2, TOPIC3)) {
+            Map<Broker, Integer> leaderCountsByBroker = new HashMap<>();
+
+            for (Partition partition : partitionsByTopic.get(topic)) {
+                leaderCountsByBroker.compute(
+                        partition.leader().broker(),
+                        (broker, count) -> count == null ? 1 : count + 1);
+            }
+
+            int numPartitions = partitionsByTopic.get(topic).size();
+            int floorNumLeadPartitionsPerBroker = Math.floorDiv(numPartitions, NUM_BROKERS);
+            int expectedNumPlusOneBrokers = numPartitions % NUM_BROKERS;
+
+            int numPlusOneBrokers = 0;
+
+            for (Integer numLeadPartitions : leaderCountsByBroker.values()) {
+
+                if (numLeadPartitions == floorNumLeadPartitionsPerBroker + 1) {
+                    numPlusOneBrokers++;
+                } else if (numLeadPartitions != floorNumLeadPartitionsPerBroker) {
+                    fail(String.format(
+                            "Expected %s or %s lead partitions for topic %s but got %s: %s",
+                            floorNumLeadPartitionsPerBroker,
+                            floorNumLeadPartitionsPerBroker + 1,
+                            topic,
+                            numLeadPartitions,
+                            leaderCountsByBroker));
+                }
+            }
+
+            System.out.println(topic);
+            assertEquals(expectedNumPlusOneBrokers, numPlusOneBrokers);
+        }
+    }
+
+    @Test
+    public void testActionAcceptance() throws KafkaCruiseControlException {
+        ClusterModel clusterModel = generateClusterModel();
+
+        // TopicLeadershipDistributionGoal assumes RackAwareGoal has already run.
+        Goal rackAwareGoal = initializeGoal(new RackAwareGoal());
+        rackAwareGoal.optimize(
+                clusterModel,
+                Collections.emptySet(),
+                new OptimizationOptions(Collections.emptySet(), Collections.emptySet(), Collections.emptySet()));
+
+        Goal goal = initializeGoal(new TopicLeadershipDistributionGoal());
+        goal.optimize(
+                clusterModel,
+                Set.of(rackAwareGoal),
+                new OptimizationOptions(Collections.emptySet(), Collections.emptySet(), Collections.emptySet()));
+
+        Map<Integer, Integer> topic0LeaderCountByBroker = new HashMap<>();
+        for (Partition partition : clusterModel.getPartitionsByTopic().get(TOPIC0)) {
+            topic0LeaderCountByBroker.compute(
+                    partition.leader().broker().id(),
+                    (brokerId, leaderCount) -> leaderCount == null ? 1 : leaderCount + 1);
+        }
+
+        Broker topic0OccupiedBroker = clusterModel.aliveBrokers().stream()
+                .filter(b -> topic0LeaderCountByBroker.containsKey(b.id()))
+                .findAny()
+                .orElseThrow(() -> new RuntimeException("Expected an occupied broker for topic0"));
+        Broker topic0OtherOccupiedBroker = clusterModel.aliveBrokers().stream()
+                .filter(b -> topic0LeaderCountByBroker.containsKey(b.id()) && !b.equals(topic0OccupiedBroker))
+                .findAny()
+                .orElseThrow(() -> new RuntimeException("Expected another occupied broker for topic0"));
+        Broker topic0UnoccupiedBroker = clusterModel.aliveBrokers().stream()
+                .filter(b -> !topic0LeaderCountByBroker.containsKey(b.id()))
+                .findAny()
+                .orElseThrow(() -> new RuntimeException("Expected an unoccupied broker for topic0"));
+
+        TopicPartition topic0Partition = topic0OccupiedBroker.replicasOfTopicInBroker(TOPIC0).stream()
+                .filter(Replica::isLeader)
+                .findAny()
+                .orElseThrow(() -> new RuntimeException(
+                        "Expected at least one replica for topic0 on broker " + topic0OccupiedBroker.id()))
+                .topicPartition();
+
+        // ACCEPT: Move a lead replica of topic0 from an occupied broker to an unoccupied broker (occupied brokers are
+        //         essentially +1 brokers)
+
+        ActionAcceptance accept1 = goal.actionAcceptance(
+                new BalancingAction(
+                        topic0Partition,
+                        topic0OccupiedBroker.id(),
+                        topic0UnoccupiedBroker.id(),
+                        ActionType.INTER_BROKER_REPLICA_MOVEMENT),
+                clusterModel);
+
+        assertEquals(ActionAcceptance.ACCEPT, accept1);
+
+        // REPLICA_REJECT: Move a lead replica of topic0 from an occupied broker to another occupied broker (occupied
+        //                 brokers are essentially +1 brokers)
+
+        ActionAcceptance reject1 = goal.actionAcceptance(
+                new BalancingAction(
+                        topic0Partition,
+                        topic0OccupiedBroker.id(),
+                        topic0OtherOccupiedBroker.id(),
+                        ActionType.INTER_BROKER_REPLICA_MOVEMENT),
+                clusterModel);
+
+        assertEquals(ActionAcceptance.REPLICA_REJECT, reject1);
+
+        // REPLICA_REJECT: Move any lead replica of topic3
+
+        TopicPartition topic3Partition = topic0OccupiedBroker.replicasOfTopicInBroker(TOPIC3).stream()
+                .filter(Replica::isLeader)
+                .findAny()
+                .orElseThrow(() -> new RuntimeException(
+                        "Expected at least one replica for topic3 on broker " + topic0OccupiedBroker.id()))
+                .topicPartition();
+
+        ActionAcceptance reject2 = goal.actionAcceptance(
+                new BalancingAction(
+                        topic3Partition,
+                        1,
+                        3,
+                        ActionType.INTER_BROKER_REPLICA_MOVEMENT),
+                clusterModel);
+
+        assertEquals(ActionAcceptance.REPLICA_REJECT, reject2);
+    }
+
+    private Goal initializeGoal(Goal goal) {
+        // These two need to be set but the goal doesn't actually use it so we're setting them to empty strings here
+        goal.configure(Map.of(BOOTSTRAP_SERVERS_CONFIG, "", ZOOKEEPER_CONNECT_CONFIG, ""));
+
+        return goal;
+    }
+
+    private ClusterModel generateClusterModel() {
+        ClusterModel clusterModel = new ClusterModel(
+                new ModelGeneration(0, 0),
+                1.0);
+
+        for (int i = 0; i < NUM_RACKS; i++) {
+            clusterModel.createRack("r" + i);
+        }
+
+        BrokerCapacityInfo capacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY);
+
+        List<Broker> brokers = new ArrayList<>();
+
+        for (int i = 1; i <= NUM_BROKERS; i++) {
+            String rack = "r" + (i % NUM_RACKS);
+            String host = "h" + i;
+
+            brokers.add(clusterModel.createBroker(rack, host, i, capacityInfo, false));
+        }
+
+        List<TopicPartition> topicPartitions = Arrays.asList(
+                // This topic should result in 3 brokers at +1 lead replicas
+                new TopicPartition(TOPIC0, 0),
+                new TopicPartition(TOPIC0, 1),
+                new TopicPartition(TOPIC0, 2),
+
+                // This topic should result in a single broker at +1 lead replicas
+                new TopicPartition(TOPIC1, 0),
+                new TopicPartition(TOPIC1, 1),
+                new TopicPartition(TOPIC1, 2),
+                new TopicPartition(TOPIC1, 3),
+                new TopicPartition(TOPIC1, 4),
+                new TopicPartition(TOPIC1, 5),
+                new TopicPartition(TOPIC1, 6),
+
+                // This topic should result in 2 brokers at +1 lead replicas
+                new TopicPartition(TOPIC2, 0),
+                new TopicPartition(TOPIC2, 1),
+                new TopicPartition(TOPIC2, 2),
+                new TopicPartition(TOPIC2, 3),
+                new TopicPartition(TOPIC2, 4),
+                new TopicPartition(TOPIC2, 5),
+                new TopicPartition(TOPIC2, 6),
+                new TopicPartition(TOPIC2, 7),
+
+                // This topic should also be perfectly distributed (all brokers at +0 lead replicas)
+                new TopicPartition(TOPIC3, 0),
+                new TopicPartition(TOPIC3, 1),
+                new TopicPartition(TOPIC3, 2),
+                new TopicPartition(TOPIC3, 3),
+                new TopicPartition(TOPIC3, 4),
+                new TopicPartition(TOPIC3, 5),
+                new TopicPartition(TOPIC3, 6),
+                new TopicPartition(TOPIC3, 7),
+                new TopicPartition(TOPIC3, 8),
+                new TopicPartition(TOPIC3, 9),
+                new TopicPartition(TOPIC3, 10),
+                new TopicPartition(TOPIC3, 11)
+        );
+
+        // Bring all topics to RF=3, all with replica sets of {1, 2, 3}
+        for (TopicPartition tp : topicPartitions) {
+            for (int i = 0; i < 3; i++) {
+                clusterModel.createReplica(
+                        brokers.get(i).rack().id(),
+                        brokers.get(i).id(),
+                        tp,
+                        i,
+                        i == 0,
+                        false,
+                        null,
+                        false);
+
+                MetricValues metricValues = new MetricValues(1);
+                Map<Short, MetricValues> metricValuesByResource = new HashMap<>();
+                Resource.cachedValues().forEach(r -> {
+                    for (short id : KafkaMetricDef.resourceToMetricIds(r)) {
+                        metricValuesByResource.put(id, metricValues);
+                    }
+                });
+                clusterModel.setReplicaLoad(
+                        brokers.get(i).rack().id(),
+                        brokers.get(i).id(),
+                        tp,
+                        new AggregatedMetricValues(metricValuesByResource),
+                        Collections.singletonList(1L));
+            }
+        }
+
+        return clusterModel;
+    }
+}


### PR DESCRIPTION
This PR adds a couple of optimizations to `TopicLeadershipDistributionGoal`:
- Track leadership counts by topic and broker/rack within `ClusterModel`
- Pre-build the `_allowedBrokers` set for `TopicLeadershipDistributionGoal.LeadershipCounts`
