### PR TITLE
Update log4j to address security vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ project(':cruise-control-core') {
       exclude group: 'log4j', module: 'log4j'
     }
     api "org.slf4j:slf4j-api:1.7.32"
-    api "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+    api "org.apache.logging.log4j:log4j-slf4j-impl:2.15.0"
     api 'org.apache.commons:commons-math3:3.6.1'
     api "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
 


### PR DESCRIPTION
This PR resolves a log4j security vulnerability that was found on Dec 9.

https://www.randori.com/blog/cve-2021-44228/